### PR TITLE
Apply pastel redesign

### DIFF
--- a/src/modules/account/components/address-card/add-address.tsx
+++ b/src/modules/account/components/address-card/add-address.tsx
@@ -137,7 +137,7 @@ const AddAddress = ({
             </div>
             {formState.error && (
               <div
-                className="text-rose-500 text-small-regular py-2"
+                className="text-primary text-small-regular py-2"
                 data-testid="address-error"
               >
                 {formState.error}

--- a/src/modules/account/components/address-card/edit-address-modal.tsx
+++ b/src/modules/account/components/address-card/edit-address-modal.tsx
@@ -211,7 +211,7 @@ const EditAddress: React.FC<EditAddressProps> = ({
               />
             </div>
             {formState.error && (
-              <div className="text-rose-500 text-small-regular py-2">
+              <div className="text-primary text-small-regular py-2">
                 {formState.error}
               </div>
             )}

--- a/src/modules/account/components/transfer-request-form/index.tsx
+++ b/src/modules/account/components/transfer-request-form/index.tsx
@@ -50,7 +50,7 @@ export default function TransferRequestForm() {
         </form>
       </div>
       {!state.success && state.error && (
-        <Text className="text-base-regular text-rose-500 text-right">
+        <Text className="text-base-regular text-primary text-right">
           {state.error}
         </Text>
       )}

--- a/src/modules/checkout/components/error-message/index.tsx
+++ b/src/modules/checkout/components/error-message/index.tsx
@@ -1,10 +1,19 @@
-const ErrorMessage = ({ error, 'data-testid': dataTestid }: { error?: string | null, 'data-testid'?: string }) => {
+const ErrorMessage = ({
+  error,
+  "data-testid": dataTestid,
+}: {
+  error?: string | null
+  "data-testid"?: string
+}) => {
   if (!error) {
     return null
   }
 
   return (
-    <div className="pt-2 text-rose-500 text-small-regular" data-testid={dataTestid}>
+    <div
+      className="pt-2 text-primary text-small-regular"
+      data-testid={dataTestid}
+    >
       <span>{error}</span>
     </div>
   )

--- a/src/modules/common/components/input/index.tsx
+++ b/src/modules/common/components/input/index.tsx
@@ -54,7 +54,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             className="flex items-center justify-center mx-3 px-1 transition-all absolute duration-300 top-3 -z-1 origin-0 text-ui-fg-subtle"
           >
             {label}
-            {required && <span className="text-rose-500">*</span>}
+            {required && <span className="text-primary">*</span>}
           </label>
           {type === "password" && (
             <button

--- a/src/modules/home/components/hero/index.tsx
+++ b/src/modules/home/components/hero/index.tsx
@@ -1,35 +1,25 @@
-import { Github } from "@medusajs/icons"
-import { Button, Heading } from "@medusajs/ui"
+import { Heading } from "@medusajs/ui"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
 
 const Hero = () => {
   return (
-    <div className="h-[75vh] w-full border-b border-ui-border-base relative bg-ui-bg-subtle">
-      <div className="absolute inset-0 z-10 flex flex-col justify-center items-center text-center small:p-32 gap-6">
-        <span>
-          <Heading
-            level="h1"
-            className="text-3xl leading-10 text-ui-fg-base font-normal"
-          >
-            Стартовый шаблон электронной коммерции
-          </Heading>
-          <Heading
-            level="h2"
-            className="text-3xl leading-10 text-ui-fg-subtle font-normal"
-          >
-            Работает на Medusa и Next.js
-          </Heading>
-        </span>
-        <a
-          href="https://github.com/medusajs/nextjs-starter-medusa"
-          target="_blank"
-        >
-          <Button variant="secondary">
-            Посмотреть на GitHub
-            <Github />
-          </Button>
-        </a>
-      </div>
-    </div>
+    <section className="h-[70vh] w-full bg-primary flex flex-col justify-center items-center text-center gap-6 px-4">
+      <Heading
+        level="h1"
+        className="text-5xl sm:text-7xl font-fredoka-bold text-choco drop-shadow"
+      >
+        munchy
+      </Heading>
+      <p className="text-lg sm:text-2xl text-choco max-w-md">
+        Самые вкусные десерты рядом с вами
+      </p>
+      <LocalizedClientLink
+        href="/store"
+        className="px-6 py-3 rounded-2xl bg-choco text-white text-xl hover:bg-opacity-80 transition"
+      >
+        Смотреть меню
+      </LocalizedClientLink>
+    </section>
   )
 }
 

--- a/src/modules/layout/components/cart-dropdown/index.tsx
+++ b/src/modules/layout/components/cart-dropdown/index.tsx
@@ -113,7 +113,7 @@ const CartDropdown = ({
                     })
                     .map((item) => (
                       <div
-                        className="grid grid-cols-[100px_1fr] gap-6 bg-pink-50 rounded-2xl p-6 shadow-lg"
+                        className="grid grid-cols-[100px_1fr] gap-6 bg-beige rounded-2xl p-6 shadow-lg"
                         key={item.id}
                         data-testid="cart-item"
                       >
@@ -158,7 +158,7 @@ const CartDropdown = ({
                             />
                             <DeleteButton
                               id={item.id}
-                              className="rounded-full p-2 hover:bg-pink-100 transition ease-out duration-200"
+                              className="rounded-full p-2 hover:bg-cream transition ease-out duration-200"
                               data-testid="cart-item-remove-button"
                             >
                               Удалить
@@ -186,7 +186,7 @@ const CartDropdown = ({
                   </div>
                   <LocalizedClientLink href="/cart" passHref>
                     <Button
-                      className="w-full rounded-2xl bg-[#feb9cc] text-white hover:bg-opacity-90 transition ease-out duration-200"
+                      className="w-full rounded-2xl bg-primary text-white hover:bg-opacity-90 transition ease-out duration-200"
                       size="large"
                       data-testid="go-to-cart-button"
                     >
@@ -197,14 +197,14 @@ const CartDropdown = ({
               </>
             ) : (
               <div className="flex flex-col items-center justify-center gap-4 py-16">
-                <div className="bg-[#feb9cc] text-white w-8 h-8 flex items-center justify-center rounded-full">
+                <div className="bg-primary text-white w-8 h-8 flex items-center justify-center rounded-full">
                   <span>0</span>
                 </div>
                 <span className="text-base">Ваша корзина пуста.</span>
                 <LocalizedClientLink href="/store">
                   <Button
                     onClick={close}
-                    className="rounded-2xl bg-[#feb9cc] text-white hover:bg-opacity-90 transition ease-out duration-200"
+                    className="rounded-2xl bg-primary text-white hover:bg-opacity-90 transition ease-out duration-200"
                   >
                     Посмотреть продукты
                   </Button>

--- a/src/modules/layout/components/side-menu/index.tsx
+++ b/src/modules/layout/components/side-menu/index.tsx
@@ -82,7 +82,7 @@ const SideMenu = ({ regions }: SideMenuProps) => {
                           href={href}
                           onClick={close}
                           data-testid={`${name.toLowerCase()}-link`}
-                          className="text-xl sm:text-2xl font-bold text-gray-800 hover:text-[#feb9cc] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-400 transition ease-out duration-200"
+                          className="text-xl sm:text-2xl font-bold text-gray-800 hover:text-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-400 transition ease-out duration-200"
                         >
                           {name}
                         </LocalizedClientLink>

--- a/src/modules/layout/templates/footer/index.tsx
+++ b/src/modules/layout/templates/footer/index.tsx
@@ -50,7 +50,7 @@ export default async function Footer() {
                     <li key={item.href}>
                       <LocalizedClientLink
                         href={item.href}
-                        className="text-base text-gray-600 hover:text-[#feb9cc] transition-colors duration-200"
+                        className="text-base text-gray-600 hover:text-primary transition-colors duration-200"
                       >
                         {item.name}
                       </LocalizedClientLink>
@@ -64,7 +64,7 @@ export default async function Footer() {
       </div>
 
       {/* Нижний розовый блок */}
-      <div className="bg-[#feb9cc] w-full">
+      <div className="bg-primary w-full">
         <div className="content-container py-16 flex flex-col items-center gap-y-4">
           <h1 className="text-[5rem] font-black leading-none">munchy</h1>
           <div className="flex items-center gap-x-4 text-gray-800 text-sm">

--- a/src/modules/layout/templates/nav/index.tsx
+++ b/src/modules/layout/templates/nav/index.tsx
@@ -10,8 +10,8 @@ export default async function Nav() {
   const regions = await listRegions().then((regions: StoreRegion[]) => regions)
 
   return (
-    <div className="sticky top-0 inset-x-0 z-50 bg-[#feb9cc]">
-      <header className="relative mx-auto bg-[#feb9cc]">
+    <div className="sticky top-0 inset-x-0 z-50 bg-primary">
+      <header className="relative mx-auto bg-primary">
         <nav className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
           {/* Side menu button */}
           <div className="flex items-center">
@@ -35,7 +35,7 @@ export default async function Nav() {
           <div>
             <LocalizedClientLink
               href="/"
-              className="text-5xl font-fredoka-bold text-black hover:text-rose-800 transition"
+              className="text-5xl font-fredoka-bold text-black hover:text-choco transition"
               data-testid="nav-store-link"
             >
               munchy

--- a/src/modules/locations/templates/index.tsx
+++ b/src/modules/locations/templates/index.tsx
@@ -73,9 +73,9 @@ const LocationsTemplate: React.FC = () => {
   }, [])
 
   return (
-    <section className="bg-rose-50 py-12">
+    <section className="bg-beige py-12">
       <div className="max-w-5xl mx-auto px-4">
-        <h1 className="text-4xl font-bold text-rose-600 mb-8 text-center">
+        <h1 className="text-4xl font-bold text-choco mb-8 text-center">
           Где найти наши заведения
         </h1>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -85,7 +85,7 @@ const LocationsTemplate: React.FC = () => {
                 key={loc.id}
                 className="bg-white p-6 rounded-2xl shadow-lg hover:shadow-2xl transition-shadow"
               >
-                <h2 className="text-2xl font-semibold text-rose-700 mb-2">
+                <h2 className="text-2xl font-semibold text-choco mb-2">
                   {loc.name}
                 </h2>
                 <p className="text-gray-600">{loc.address}</p>

--- a/src/modules/products/components/product-preview/index.tsx
+++ b/src/modules/products/components/product-preview/index.tsx
@@ -30,7 +30,10 @@ export default async function ProductPreview({
 
   return (
     <LocalizedClientLink href={`/products/${product.handle}`} className="group">
-      <div data-testid="product-wrapper">
+      <div
+        data-testid="product-wrapper"
+        className="bg-white rounded-2xl shadow-lg p-4 flex flex-col gap-3 hover:shadow-xl transition"
+      >
         <Thumbnail
           thumbnail={product.thumbnail}
           images={product.images}

--- a/src/modules/products/components/thumbnail/index.tsx
+++ b/src/modules/products/components/thumbnail/index.tsx
@@ -27,7 +27,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
   return (
     <Container
       className={clx(
-        "relative w-full overflow-hidden p-4 bg-ui-bg-subtle shadow-elevation-card-rest rounded-large group-hover:shadow-elevation-card-hover transition-shadow ease-in-out duration-150",
+        "relative w-full overflow-hidden p-4 bg-beige rounded-2xl shadow-md group-hover:shadow-lg transition-shadow ease-in-out duration-150",
         className,
         {
           "aspect-[11/14]": isFeatured,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Fredoka:wght@700&family=Russo+One&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Fredoka:wght@700&family=Russo+One&display=swap");
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
@@ -112,11 +112,13 @@
   }
 }
 
-html, body {
-  font-family: 'Russo One', sans-serif;
+html,
+body {
+  font-family: "Russo One", sans-serif;
+  background-color: #fdf1e1;
 }
 
 .font-fredoka-bold {
-  font-family: 'Fredoka', sans-serif;
+  font-family: "Fredoka", sans-serif;
   font-weight: 700;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,6 +34,10 @@ module.exports = {
           80: "#1F2937",
           90: "#111827",
         },
+        primary: "#feb9cc",
+        beige: "#fdf1e1",
+        choco: "#6b3d2e",
+        cream: "#fff4e6",
       },
       borderRadius: {
         none: "0px",
@@ -41,6 +45,7 @@ module.exports = {
         base: "4px",
         rounded: "8px",
         large: "16px",
+        "2xl": "1rem",
         circle: "9999px",
       },
       maxWidth: {


### PR DESCRIPTION
## Summary
- redesign hero and product cards with new pastel theme
- add pastel color palette and 2xl radius in Tailwind config
- tweak nav, footer and cart dropdown colors
- update inputs and error text styling
- give locations page and thumbnails softer look
- set beige background site-wide

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6867ae417430832aaa51f4e95a87bb60